### PR TITLE
Updating entry point object="jarves/groups"->object="jarves/group"

### DIFF
--- a/Resources/config/jarves.entrypoints.xml
+++ b/Resources/config/jarves.entrypoints.xml
@@ -126,7 +126,7 @@
               </entryPoint>
             </children>
           </entryPoint>
-          <entryPoint path="groups" object="jarves/groups" type="combine" system="true" icon="#icon-users-2" link="true">
+          <entryPoint path="groups" object="jarves/group" type="combine" system="true" icon="#icon-users-2" link="true">
             <label>Groups</label>
           </entryPoint>
           <entryPoint path="acl" type="custom" system="true" icon="#icon-key-4" link="true">


### PR DESCRIPTION
This fixes the error when trying to access the Groups tab on the admin panel

Failed. Error Symfony\Component\HttpKernel\Exception\NotFoundHttpException: No route found for "OPTIONS /jarves/object/jarves/groups/" (from http://127.0.0.1:8000/jarves)