### PR TITLE
Use builtin keylighter mechanisms instead of own classmap

### DIFF
--- a/ContentTypes/Markdowner.php
+++ b/ContentTypes/Markdowner.php
@@ -5,6 +5,8 @@ namespace Jarves\ContentTypes;
 use Jarves\PageStack;
 use Michelf\Markdown;
 use Michelf\MarkdownExtra;
+use Kadet\Highlighter;
+use Kadet\Highlighter\Language\Language;
 
 /**
  * Extends Michelfs\Markdown with code syntax highglighting
@@ -26,45 +28,15 @@ class Markdowner
     public function transform($text)
     {
         $parser = new MarkdownExtra;
-
         $stylesAdded = false;
 
-        $classMap = [
-            'js' => 'JavaScript',
-            'javascript' => 'JavaScript',
-            'php' => 'Php',
-            'css' => 'css',
-            'scss' => 'Css\\Scss',
-            'less' => 'Css\\Less',
-            'sass' => 'Css\\Sass',
-            'ini' => 'ini',
-            'latex' => 'latex',
-            'perl' => 'perl',
-            'powershell' => 'PowerShell',
-            'sql' => 'Sql',
-            'mysql' => 'Sql\\MySQL',
-            'xml' => 'Xml',
-            'html' => 'Html',
-            'python' => 'Python',
-        ];
-        
-        $parser->code_block_content_func = function ($code, $language) use (&$stylesAdded, $classMap) {
-            if (!$stylesAdded ){
+        $parser->code_block_content_func = function ($code, $language) use (&$stylesAdded) {
+            if (!$stylesAdded){
                 $this->pageStack->getPageResponse()->addCssFile('@Jarves/keylighter/default.scss');
                 $stylesAdded = true;
             }
 
-            if (!isset($classMap[$language])) {
-                return htmlentities($code);
-            }
-
-            $class = '\\Kadet\\Highlighter\\Language\\' . $classMap[$language];
-
-            /** @var \Kadet\Highlighter\Language\Language $parser */
-            $parser = new $class();
-            $out = new \Kadet\Highlighter\Formatter\HtmlFormatter();
-
-            return $out->format($parser->parse($code));
+            return Highlighter\highlight($code, Language::byName($language));
         };
 
         return $parser->transform($text);

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6ddfda278aecdbd9b059accba3aed817",
+    "hash": "6096312012988abe53f32392e4365cc9",
     "content-hash": "fe8dcfa6cdc241679859eef7c8a75720",
     "packages": [
         {
@@ -858,12 +858,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/kadet1090/KeyLighter.git",
-                "reference": "54eb3fa9704beb18ac9880170339bed7fe81ac63"
+                "reference": "56e355258dc23a68f98ec95b348d6afecd51a00b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kadet1090/KeyLighter/zipball/54eb3fa9704beb18ac9880170339bed7fe81ac63",
-                "reference": "54eb3fa9704beb18ac9880170339bed7fe81ac63",
+                "url": "https://api.github.com/repos/kadet1090/KeyLighter/zipball/56e355258dc23a68f98ec95b348d6afecd51a00b",
+                "reference": "56e355258dc23a68f98ec95b348d6afecd51a00b",
                 "shasum": ""
             },
             "require": {
@@ -895,7 +895,7 @@
                 }
             ],
             "description": "Yet another syntax highlighter for PHP",
-            "time": "2016-04-15 22:04:59"
+            "time": "2016-06-06 14:32:01"
         },
         {
             "name": "michelf/php-markdown",


### PR DESCRIPTION
Use built-in language factory, as described at http://keylighter.kadet.net/docs/usage, instead of own probably out-of-sync class map. 